### PR TITLE
fix link icon for backend form

### DIFF
--- a/Configuration/TCA/tx_sfbanners_domain_model_banner.php
+++ b/Configuration/TCA/tx_sfbanners_domain_model_banner.php
@@ -245,11 +245,7 @@ return array(
 						'title' => 'Link',
 						'icon' => 'link_popup.gif',
 						'module' => array(
-							'name' => 'wizard_element_browser',
-							'urlParameters' => array(
-								'mode' => 'wizard',
-								'act' => 'file'
-							)
+							'name' => 'wizard_link',
 						),
 						'JSopenParams' => 'height=300,width=500,status=0,menubar=0,scrollbars=1'
 					)


### PR DESCRIPTION
Hi Torben,
you may wanna have a look at this. The link wizard icon made problems lately with 7.6.x installations. Changing the TCA as done should fix it.