### PR TITLE
Add new 'assets' field (FAL) for images

### DIFF
--- a/Classes/Domain/Model/Banner.php
+++ b/Classes/Domain/Model/Banner.php
@@ -645,7 +645,7 @@ class Banner extends AbstractEntity
             /** @var \TYPO3\CMS\Extbase\Domain\Model\FileReference $fileReference */
             $fileReference = $this->assets->current();
 
-            if ($fileReference === NULL) {
+            if ($fileReference === null) {
                 return '';
             }
 

--- a/Classes/Domain/Model/Banner.php
+++ b/Classes/Domain/Model/Banner.php
@@ -809,7 +809,6 @@ class Banner extends AbstractEntity
         return $target;
     }
 
-
     /**
      * Get the Fal media items
      *

--- a/Classes/Domain/Model/Banner.php
+++ b/Classes/Domain/Model/Banner.php
@@ -64,6 +64,14 @@ class Banner extends AbstractEntity
     protected $image;
 
     /**
+     * Fal media items
+     *
+     * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<TYPO3\CMS\Extbase\Domain\Model\FileReference>
+     * @lazy
+     */
+    protected $assets;
+
+    /**
      * Margin top
      *
      * @var int
@@ -209,6 +217,7 @@ class Banner extends AbstractEntity
     {
         $this->category = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
         $this->excludepages = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+        $this->assets = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
     }
 
     /**
@@ -781,5 +790,53 @@ class Banner extends AbstractEntity
             $ret = $linkArray[1];
         }
         return $ret;
+    }
+
+
+    /**
+     * Get the Fal media items
+     *
+     * @return \TYPO3\CMS\Extbase\Persistence\ObjectStorage<TYPO3\CMS\Extbase\Domain\Model\FileReference>
+     */
+    public function getAssets()
+    {
+        return $this->assets;
+    }
+
+    /**
+     * Set Fal media relation
+     *
+     * @param \TYPO3\CMS\Extbase\Persistence\ObjectStorage<TYPO3\CMS\Extbase\Domain\Model\FileReference> $assets
+     * @return void
+     */
+    public function setAssets(\TYPO3\CMS\Extbase\Persistence\ObjectStorage $assets)
+    {
+        $this->assets = $assets;
+    }
+
+    /**
+     * Add a Fal media file reference
+     *
+     * @param \TYPO3\CMS\Extbase\Domain\Model\FileReference $asset
+     */
+    public function addAsset(\TYPO3\CMS\Extbase\Domain\Model\FileReference $asset)
+    {
+        if ($this->getAssets() === null) {
+            $this->assets = new \TYPO3\CMS\Extbase\Persistence\ObjectStorage();
+        }
+        $this->assets->attach($asset);
+    }
+
+    /**
+     * Remove a Fal media file reference
+     *
+     * @param \TYPO3\CMS\Extbase\Domain\Model\FileReference $asset
+     */
+    public function removeAsset(\TYPO3\CMS\Extbase\Domain\Model\FileReference $asset)
+    {
+        if ($this->getAssets() === null) {
+            return;
+        }
+        $this->assets->detach($asset);
     }
 }

--- a/Classes/Domain/Model/Banner.php
+++ b/Classes/Domain/Model/Banner.php
@@ -16,6 +16,7 @@ namespace DERHANSEN\SfBanners\Domain\Model;
 
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
 /**
  * Banner domain model
@@ -638,6 +639,22 @@ class Banner extends AbstractEntity
      */
     public function getLink()
     {
+        $extConf = @unserialize($GLOBALS[ 'TYPO3_CONF_VARS' ][ 'EXT' ][ 'extConf' ][ 'sf_banners' ]);
+
+        if ($this->getType() == 0 && $extConf[ 'falMedia' ]) {
+            /** @var \TYPO3\CMS\Extbase\Domain\Model\FileReference $fileReference */
+            $fileReference = $this->assets->current();
+
+            if ($fileReference === NULL) {
+                return '';
+            }
+
+            /** @var \TYPO3\CMS\Core\Resource\FileReference $originalFileReference */
+            $originalFileReference = $fileReference->getOriginalResource();
+
+            return $originalFileReference->getLink();
+        }
+
         return $this->link;
     }
 
@@ -773,8 +790,8 @@ class Banner extends AbstractEntity
      */
     public function getLinkUrl()
     {
-        $cObj = GeneralUtility::makeInstance('TYPO3\\CMS\\Frontend\\ContentObject\\ContentObjectRenderer');
-        return $cObj->getTypoLink_URL($this->link);
+        $cObj = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+        return $cObj->getTypoLink_URL($this->getLink());
     }
 
     /**
@@ -784,12 +801,12 @@ class Banner extends AbstractEntity
      */
     public function getLinkTarget()
     {
-        $linkArray = GeneralUtility::trimExplode(' ', $this->link);
-        $ret = '';
-        if (count($linkArray) > 1) {
-            $ret = $linkArray[1];
-        }
-        return $ret;
+        $link = $this->getLink();
+        $cObj = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+        $cObj->getTypoLink_URL($link);
+        $target = $cObj->lastTypoLinkTarget;
+
+        return $target;
     }
 
 

--- a/Configuration/TCA/tx_sfbanners_domain_model_banner.php
+++ b/Configuration/TCA/tx_sfbanners_domain_model_banner.php
@@ -1,5 +1,15 @@
 <?php
 
+$sfBannersConf = @unserialize($GLOBALS[ 'TYPO3_CONF_VARS'][ 'EXT'][ 'extConf'][ 'sf_banners']);
+
+if ($sfBannersConf[ 'falMedia']) {
+    $image = 'assets,';
+    $link = '';
+} else {
+    $image = 'image,';
+    $link = 'link,';
+}
+
 return [
     'ctrl' => [
         'title' => 'LLL:EXT:sf_banners/Resources/Private/Language/locallang_db.xlf:tx_sfbanners_domain_model_banner',
@@ -25,7 +35,7 @@ return [
         'iconfile' => 'EXT:sf_banners/Resources/Public/Icons/tx_sfbanners_domain_model_banner.gif'
     ],
     'interface' => [
-        'showRecordFieldList' => 'sys_language_uid, l10n_parent, l10n_diffsource, hidden, title, description, type, category, image, margin_top, margin_right, margin_bottom, margin_left, alttext, link, html, flash, flash_width, flash_height, flash_wmode, flash_allow_script_access, impressions_max, clicks_max, impressions, clicks, excludepages, recursive',
+        'showRecordFieldList' => 'sys_language_uid, l10n_parent, l10n_diffsource, hidden, title, description, type, category, image, assets, margin_top, margin_right, margin_bottom, margin_left, alttext, link, html, flash, flash_width, flash_height, flash_wmode, flash_allow_script_access, impressions_max, clicks_max, impressions, clicks, excludepages, recursive',
     ],
     'columns' => [
         'sys_language_uid' => [
@@ -189,6 +199,38 @@ return [
                 'minitems' => 0,
                 'maxitems' => 1,
             ]
+        ],
+        'assets' => [
+            'exclude' => 0,
+            'l10n_mode' => 'mergeIfNotBlank',
+            'label' => 'LLL:EXT:sf_banners/Resources/Private/Language/locallang_db.xlf:tx_sfbanners_domain_model_banner.assets',
+            'config' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getFileFieldTCAConfig(
+                'assets',
+                [
+                    'appearance' => [
+                        'createNewRelationLinkTitle' => 'LLL:EXT:cms/locallang_ttc.xlf:images.addFileReference',
+                        'showPossibleLocalizationRecords' => 1,
+                        'showRemovedLocalizationRecords' => 1,
+                        'showAllLocalizationLink' => 1,
+                        'showSynchronizationLink' => 1
+                    ],
+                    'foreign_types' => [
+                        \TYPO3\CMS\Core\Resource\File::FILETYPE_UNKNOWN => [
+                            'showitem' => '
+                                --palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;imageoverlayPalette,
+                                --palette--;;filePalette',
+                        ],
+                        \TYPO3\CMS\Core\Resource\File::FILETYPE_IMAGE   => [
+                            'showitem' => '
+                                --palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;imageoverlayPalette,
+                                --palette--;;filePalette',
+                        ],
+                    ],
+                    'minitems' => 0,
+                    'maxitems' => 1,
+                ],
+                $GLOBALS[ 'TYPO3_CONF_VARS' ][ 'GFX' ][ 'imagefile_ext' ]
+            ),
         ],
         'margin_top' => [
             'exclude' => 0,
@@ -393,7 +435,7 @@ return [
     'types' => [
         '0' => [
             'showitem' => 'l10n_parent,l10n_diffsource,title,--palette--;;paletteCore, description,
-			--div--;LLL:EXT:sf_banners/Resources/Private/Language/locallang_db.xlf:tx_sfbanners_domain_model_banner.tabs.image,image,--palette--;;paletteMargins,alttext,link,
+			--div--;LLL:EXT:sf_banners/Resources/Private/Language/locallang_db.xlf:tx_sfbanners_domain_model_banner.tabs.image,' . $image . ',--palette--;;paletteMargins,' . $link . '
 			--div--;LLL:EXT:sf_banners/Resources/Private/Language/locallang_db.xlf:tx_sfbanners_domain_model_banner.tabs.display, category, excludepages, recursive,
 			--div--;LLL:EXT:sf_banners/Resources/Private/Language/locallang_db.xlf:tx_sfbanners_domain_model_banner.tabs.visibility, hidden,--palette--;;paletteVisibility,
 			--div--;LLL:EXT:sf_banners/Resources/Private/Language/locallang_db.xlf:tx_sfbanners_domain_model_banner.tabs.limitations, impressions_max, clicks_max,

--- a/Resources/Private/Language/de.locallang_be.xlf
+++ b/Resources/Private/Language/de.locallang_be.xlf
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<xliff version="1.0">
+	<file source-language="en" target-language="de" datatype="plaintext" original="messages" date="2015-09-10T09:28:33Z">
+		<header>
+			<type>database</type>
+			<description>Language labels for the backend belonging to extension 'sf_banners'</description>
+		</header>
+		<body>
+			<trans-unit id="extmng.enableFalMedia">
+				<source>Enable FAL banner images.</source>
+				<target>FAL für Banner-Bilder aktivieren.</target>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -87,6 +87,10 @@
 			<source>Image</source>
 			<target>Bild</target>
 		</trans-unit>
+		<trans-unit id="tx_sfbanners_domain_model_banner.assets" approved="yes">
+			<source>Assets</source>
+			<target>Bild</target>
+		</trans-unit>
 		<trans-unit id="tx_sfbanners_domain_model_banner.impressions" approved="yes">
 			<source>Impressions</source>
 			<target>Impressionen</target>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<xliff version="1.0">
+	<file source-language="en" datatype="plaintext" original="messages" date="2015-09-10T09:28:33Z">
+		<header>
+			<type>database</type>
+			<description>Language labels for the backend belonging to extension 'sf_banners'</description>
+		</header>
+		<body>
+			<trans-unit id="extmng.enableFalMedia">
+				<source>Enable FAL banner images.</source>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -67,6 +67,9 @@
 		<trans-unit id="tx_sfbanners_domain_model_banner.image">
 			<source>Image</source>
 		</trans-unit>
+		<trans-unit id="tx_sfbanners_domain_model_banner.assets">
+			<source>Assets</source>
+		</trans-unit>
 		<trans-unit id="tx_sfbanners_domain_model_banner.impressions">
 			<source>Impressions</source>
 		</trans-unit>

--- a/Resources/Private/Partials/Banner/ImageBanner.html
+++ b/Resources/Private/Partials/Banner/ImageBanner.html
@@ -1,14 +1,34 @@
-<f:if condition="{banner.image}">
-    <div class="banner banner-{banner.uid}">
-        <f:if condition="{banner.link}">
-            <f:then>
-                <f:link.action action="click" arguments="{banner: banner}" target="{banner.linkTarget}" pageType="{settings.clickPageTypeNum}">
-                    <f:image src="uploads/tx_sfbanners/{banner.image}" title="{banner.alttext}" alt="{banner.alttext}"/>
-                </f:link.action>
-            </f:then>
-            <f:else>
-                <f:image src="uploads/tx_sfbanners/{banner.image}" title="{banner.alttext}" alt="{banner.alttext}"/>
-            </f:else>
+<f:if condition="{banner.assets}">
+    <f:then>
+        <f:for each="{banner.assets}" as="asset">
+            <div class="banner banner-{banner.uid}">
+                <f:if condition="{banner.link}">
+                    <f:then>
+                        <f:link.action action="click" arguments="{banner: banner}" target="{banner.linkTarget}" pageType="{settings.clickPageTypeNum}">
+                            <f:image image="{asset}" title="{banner.alttext}" alt="{banner.alttext}" />
+                        </f:link.action>
+                    </f:then>
+                    <f:else>
+                        <f:image image="{asset}" title="{banner.alttext}" alt="{banner.alttext}" />
+                    </f:else>
+                </f:if>
+            </div>
+        </f:for>
+    </f:then>
+    <f:else>
+        <f:if condition="{banner.image}">
+            <div class="banner banner-{banner.uid}">
+                <f:if condition="{banner.link}">
+                    <f:then>
+                        <f:link.action action="click" arguments="{banner: banner}" target="{banner.linkTarget}" pageType="{settings.clickPageTypeNum}">
+                            <f:image src="uploads/tx_sfbanners/{banner.image}" title="{banner.alttext}" alt="{banner.alttext}" />
+                        </f:link.action>
+                    </f:then>
+                    <f:else>
+                        <f:image src="uploads/tx_sfbanners/{banner.image}" title="{banner.alttext}" alt="{banner.alttext}" />
+                    </f:else>
+                </f:if>
+            </div>
         </f:if>
-    </div>
+    </f:else>
 </f:if>

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,0 +1,2 @@
+# cat=backend/settings; type=boolean; label=LLL:EXT:sf_banners/Resources/Private/Language/locallang_be.xlf:extmng.enableFalMedia
+falMedia = 0

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -56,6 +56,7 @@ CREATE TABLE tx_sfbanners_domain_model_banner (
 	type int(11) DEFAULT '0' NOT NULL,
 	category int(11) DEFAULT '0' NOT NULL,
 	image text,
+	assets int(11) DEFAULT '0' NOT NULL,
 	margin_top int(11) DEFAULT '0' NOT NULL,
 	margin_right int(11) DEFAULT '0' NOT NULL,
 	margin_bottom int(11) DEFAULT '0' NOT NULL,


### PR DESCRIPTION
The assets field exists side-by-side with the old `image` field. It is disabled by default.
To switch from `image` to 'assets', one may use the `falMedia` extension configuration option.