### PR TITLE
Changed version requirements to include TYPO3 9.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "GPL-2.0+"
   ],
   "require": {
-    "typo3/cms-core": "^7.6 || ^8.5"
+    "typo3/cms-core": "^7.6 || ^8.5 || ^9.5"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.8.0",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -29,8 +29,8 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '3.0.1',
     'constraints' => [
         'depends' => [
-            'typo3' => '7.6.0-8.7.99',
-            'php' => '5.4.0-7.1.99',
+            'typo3' => '7.6.0-9.5.99',
+            'php' => '5.4.0-7.2.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
Tested with only version constraints changed, on a TYPO3 9.5