### PR TITLE
set the second argument to INT in ImmediateResponseException

### DIFF
--- a/Classes/Controller/BannerController.php
+++ b/Classes/Controller/BannerController.php
@@ -113,7 +113,7 @@ class BannerController extends ActionController
                 $GLOBALS['TYPO3_REQUEST'],
                 'Banner not found.'
             );
-            throw new ImmediateResponseException($response, 1549896549734);
+            throw new ImmediateResponseException($response, 1549896549);
         }
         $banner->increaseClicks();
         $this->bannerRepository->update($banner);


### PR DESCRIPTION
on a 32 bit php system the max int number may only be up to 2147483647. 
see https://www.php.net/manual/de/language.types.integer.php