### PR TITLE
[TASK] TCA Migrations

### DIFF
--- a/Configuration/TCA/tx_sfbanners_domain_model_banner.php
+++ b/Configuration/TCA/tx_sfbanners_domain_model_banner.php
@@ -38,6 +38,20 @@ return [
                 'type' => 'language',
             ],
         ],
+        'l10n_parent' => [
+            'displayCond' => 'FIELD:sys_language_uid:>:0',
+            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => [
+                    ['', 0],
+                ],
+                'foreign_table' => 'tx_sfbanners_domain_model_banner',
+                'foreign_table_where' => 'AND tx_sfbanners_domain_model_banner.pid=###CURRENT_PID### AND tx_sfbanners_domain_model_banner.sys_language_uid IN (-1,0)',
+                'default' => 0,
+            ],
+        ],
         'l10n_diffsource' => [
             'config' => [
                 'type' => 'passthrough',

--- a/Configuration/TCA/tx_sfbanners_domain_model_banner.php
+++ b/Configuration/TCA/tx_sfbanners_domain_model_banner.php
@@ -26,11 +26,6 @@ return [
             'default' => 'ext-sfbanners-banner'
         ],
     ],
-    'interface' => [
-        'showRecordFieldList' => 'sys_language_uid, l10n_parent, l10n_diffsource, hidden, title, description, type, 
-            category, assets, html, 
-            impressions_max, clicks_max, impressions, clicks, excludepages, recursive',
-    ],
     'palettes' => [
         'paletteVisibility' => ['showitem' => 'starttime, endtime'],
         'paletteLanguage' => ['showitem' => 'sys_language_uid, l10n_parent, l10n_diffsource'],
@@ -41,21 +36,6 @@ return [
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
                 'type' => 'language',
-            ],
-        ],
-        'l10n_parent' => [
-            'displayCond' => 'FIELD:sys_language_uid:>:0',
-            'exclude' => 0,
-            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
-            'config' => [
-                'type' => 'select',
-                'renderType' => 'selectSingle',
-                'items' => [
-                    ['', 0],
-                ],
-                'foreign_table' => 'tx_sfbanners_domain_model_banner',
-                'foreign_table_where' => 'AND tx_sfbanners_domain_model_banner.pid=###CURRENT_PID### AND tx_sfbanners_domain_model_banner.sys_language_uid IN (-1,0)',
-                'default' => 0,
             ],
         ],
         'l10n_diffsource' => [


### PR DESCRIPTION
This MR remove from TCA Migrations  two problems

The 'tx_sfbanners_domain_model_banner' TCA tables transOrigPointerField 'l10n_parent' is defined as excluded field which is no longer needed and should therefore be removed.
The 'tx_sfbanners_domain_model_banner' TCA configuration 'showRecordFieldList' inside the section 'interface' is not evaluated anymore and should therefore be removed.                              